### PR TITLE
bump python to 3.10.8 and disable pip cache

### DIFF
--- a/datastore-api/Dockerfile
+++ b/datastore-api/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.10.8-slim-buster as base
 
+ENV PYTHONUNBUFFERED=1
+ENV PIP_NO_CACHE_DIR=1
+
 # required to install packages from github
 RUN apt-get -y update && apt-get -y install git
 

--- a/datastore-api/Dockerfile
+++ b/datastore-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.8-slim-buster as base
+FROM python:3.7.6-slim-buster as base
 
 ENV PYTHONUNBUFFERED=1
 ENV PIP_NO_CACHE_DIR=1

--- a/datastore-api/Dockerfile
+++ b/datastore-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.6-slim-buster as base
+FROM python:3.10.8-slim-buster as base
 
 # required to install packages from github
 RUN apt-get -y update && apt-get -y install git

--- a/datastore-api/requirements.dev.txt
+++ b/datastore-api/requirements.dev.txt
@@ -4,3 +4,4 @@ requests-mock>=1.9.3
 pytest-cov>=3.0.0
 pytest-mock>=3.7.0
 testcontainers==3.4.2
+httpx

--- a/skill-manager/Dockerfile
+++ b/skill-manager/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.10.8-slim-buster as base
 
+ENV PYTHONUNBUFFERED=1
+ENV PIP_NO_CACHE_DIR=1
+
 # required to install packages from github
 RUN apt-get -y update && apt-get -y install git
 

--- a/skill-manager/Dockerfile
+++ b/skill-manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.6-slim-buster as base
+FROM python:3.10.8-slim-buster as base
 
 # required to install packages from github
 RUN apt-get -y update

--- a/skill-manager/requirements.dev.txt
+++ b/skill-manager/requirements.dev.txt
@@ -10,3 +10,4 @@ python-keycloak>=0.26.1
 pytest-env>=0.6.2
 pyjwt>=2.3.0
 pytest-asyncio>=0.18.2
+httpx

--- a/skills/Dockerfile.template
+++ b/skills/Dockerfile.template
@@ -1,6 +1,7 @@
 FROM python:3.10.8-slim-buster as base
 
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
+ENV PIP_NO_CACHE_DIR=1
 
 RUN apt-get -y update && apt-get -y install git
 

--- a/skills/Dockerfile.template
+++ b/skills/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM python:3.7.6-slim-buster as base
+FROM python:3.10.8-slim-buster as base
 
 ENV PYTHONUNBUFFERED 1
 

--- a/square-frontend/Dockerfile_production
+++ b/square-frontend/Dockerfile_production
@@ -12,7 +12,7 @@ COPY square-frontend/. .
 RUN npm run build
 
 # docs stage
-FROM python:3.7.6-buster as docs-stage
+FROM python:3.10.8-buster as docs-stage
 
 RUN apt-get -y update
 RUN apt-get -y install git

--- a/square-frontend/package.json
+++ b/square-frontend/package.json
@@ -3,9 +3,9 @@
   "version": "0.2.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "serve": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service serve",
+    "build": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service build",
+    "lint": "export NODE_OPTIONS=--openssl-legacy-provider && vue-cli-service lint"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.5",

--- a/square-model-inference-api/inference_server/Dockerfile
+++ b/square-model-inference-api/inference_server/Dockerfile
@@ -31,7 +31,7 @@ FROM base as test
 COPY ./tests/pre_test_setup_for_docker_caching.py ./tests/pre_test_setup_for_docker_caching.py
 RUN python ./tests/pre_test_setup_for_docker_caching.py
 COPY . ./
-RUN pip install pytest pytest-cov pytest-asyncio pytest-env
+RUN pip install pytest pytest-cov pytest-asyncio pytest-env httpx
 RUN mkdir test-reports
 RUN PYTHONPATH=./ pytest \
     --junitxml=test-reports/junit.xml \

--- a/square-model-inference-api/inference_server/Dockerfile
+++ b/square-model-inference-api/inference_server/Dockerfile
@@ -28,10 +28,12 @@ RUN pip install -r requirements2.txt
 # run the tests
 FROM base as test
 
+COPY requirements.dev.txt ./
+RUN pip install -r requirements.dev.txt
+
 COPY ./tests/pre_test_setup_for_docker_caching.py ./tests/pre_test_setup_for_docker_caching.py
 RUN python ./tests/pre_test_setup_for_docker_caching.py
 COPY . ./
-RUN pip install pytest pytest-cov pytest-asyncio pytest-env httpx
 RUN mkdir test-reports
 RUN PYTHONPATH=./ pytest \
     --junitxml=test-reports/junit.xml \

--- a/square-model-inference-api/inference_server/Dockerfile
+++ b/square-model-inference-api/inference_server/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.10.8-slim-buster as base
 
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
+ENV PIP_NO_CACHE_DIR=1
 
 # required to install packages from github
 RUN apt-get -y update && apt-get -y install git rabbitmq-server

--- a/square-model-inference-api/inference_server/Dockerfile
+++ b/square-model-inference-api/inference_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.6-slim-buster as base
+FROM python:3.10.8-slim-buster as base
 
 ENV PYTHONUNBUFFERED 1
 

--- a/square-model-inference-api/inference_server/dockerfiles/graph_transformer/Dockerfile
+++ b/square-model-inference-api/inference_server/dockerfiles/graph_transformer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.6-slim-buster as base
+FROM python:3.10.8-slim-buster as base
 
 ENV PYTHONUNBUFFERED 1
 

--- a/square-model-inference-api/inference_server/dockerfiles/onnx/Dockerfile
+++ b/square-model-inference-api/inference_server/dockerfiles/onnx/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.6-slim-buster as base
+FROM python:3.10.8-slim-buster as base
 
 ENV PYTHONUNBUFFERED 1
 

--- a/square-model-inference-api/inference_server/dockerfiles/sentence_transformer/Dockerfile
+++ b/square-model-inference-api/inference_server/dockerfiles/sentence_transformer/Dockerfile
@@ -1,5 +1,5 @@
 ## This is the dockerfile template for transformer based model
-FROM python:3.7.6-slim-buster as base
+FROM python:3.10.8-slim-buster as base
 
 ENV PYTHONUNBUFFERED 1
 

--- a/square-model-inference-api/inference_server/dockerfiles/transformer/Dockerfile
+++ b/square-model-inference-api/inference_server/dockerfiles/transformer/Dockerfile
@@ -1,5 +1,5 @@
 ## This is the dockerfile template for transformer based model
-FROM python:3.9.14-slim-buster as base
+FROM python:3.10.8-slim-buster as base
 
 ENV PYTHONUNBUFFERED 1
 

--- a/square-model-inference-api/inference_server/requirements.dev.txt
+++ b/square-model-inference-api/inference_server/requirements.dev.txt
@@ -1,0 +1,5 @@
+pytest
+pytest-cov
+pytest-asyncio
+pytest-env
+httpx

--- a/square-model-inference-api/inference_server/uninstall_requirements.txt
+++ b/square-model-inference-api/inference_server/uninstall_requirements.txt
@@ -1,3 +1,1 @@
 transformers
-joblib>=1.2.0 # not directly required, pinned by Snyk to avoid a vulnerability
-numpy>=1.22.2 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/square-model-inference-api/management_server/Dockerfile
+++ b/square-model-inference-api/management_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.14-slim-buster as base
+FROM python:3.10.8-slim-buster as base
 
 ENV PYTHONUNBUFFERED=1
 ENV PIP_NO_CACHE_DIR=1

--- a/square-model-inference-api/management_server/Dockerfile
+++ b/square-model-inference-api/management_server/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.9.14-slim-buster as base
 
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
+ENV PIP_NO_CACHE_DIR=1
 
 RUN apt-get -y update
 RUN apt-get -y install git


### PR DESCRIPTION
# What does this PR do?
Bump version of all python images from 3.7 to 3.10.8 (Except datastores due to some error).
Disable pip cache to make docker images slimmer.
