### PR TITLE
install square libraries from pypi

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,7 @@ skills:
   - name: qa-gnn
     author: ukp
   - name: information-retrieval
-    author: serwar
+    author: ukp
 
 web_concurrency: 2
 

--- a/datastore-api/logging.conf
+++ b/datastore-api/logging.conf
@@ -17,5 +17,5 @@ formatter = json
 keys = json
 
 [formatter_json]
-class = elk_json_formatter.ElkJsonFormatter
+class = square_elk_json_formatter.ElkJsonFormatter
 

--- a/datastore-api/requirements.txt
+++ b/datastore-api/requirements.txt
@@ -8,7 +8,7 @@ python-multipart>=0.0.5
 requests>=2.25.1
 numpy>=1.21.5
 uvicorn[standard]>=0.14.0
-square-auth>=0.0.7
+square-auth>=0.0.11
 pymongo==4.0.2
 pyjwt==2.4.0
 aiohttp>=3.8.1

--- a/datastore-api/requirements.txt
+++ b/datastore-api/requirements.txt
@@ -12,4 +12,4 @@ square-auth>=0.0.7
 pymongo==4.0.2
 pyjwt==2.4.0
 aiohttp>=3.8.1
-git+https://github.com/UKP-SQuARE/elk-json-formatter.git@v0.0.2
+square-elk-json-formatter==0.0.3

--- a/docs/home/components/skills.md
+++ b/docs/home/components/skills.md
@@ -66,8 +66,8 @@ If you want to create a new skill that does not follow the previously described 
 As mentioned above mainly a predict function, defining the pipeline needs to be implemented. 
 First, install the required packages:
 ```bash
-pip install git+https://github.com/UKP-SQuARE/square-skill-helpers.git@v0.0.9
-pip install git+https://github.com/UKP-SQuARE/square-skill-api.git@v0.0.34  
+pip install square-skill-helpers
+pip install square-skill-api 
 ```
 Next, we can implement the `predict` function:
 ```python3

--- a/docs/home/components/skills.md
+++ b/docs/home/components/skills.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 3
----
-
 # Skills
 Skills define how the user query should be processed by the Datastores and Models services and how the answers are obtained. For question answering, this might involve retrieving background knowledge from the Datastores and/or extracting spans from context using a particular Model and Adapter.
 
@@ -10,85 +6,37 @@ Skills can be added dynamically to UKP-SQuARE. Check out the 👉 [Add New Skill
 For a list of available skills, see 👉 [Publicly Available Skills](#publicly-available-skills).
 
 ## Add New Skills
-### Via UI for Standard QA pipelines
-The user interface allows the creation of "standard" QA pipelines (i.e., extractive, multiple-choice, categorial/boolean, abstractive, and open-retrieval). If your skill belongs to one of these types, you can easily create deploy your skill effortlessly as follows:
-
-- skill_type: 
-    - extractive for both extractive and open-retrieval
-    - categorial for boolean skills
-    - multiple_choice for multiple choice
-    - abtractive for generative skills
-- Skill url
-    - http://extractive-qa for extractive Skills
-    - http://multiple-choice-qa for both categorial and multiple-choice Skills.
-    - http://generative-qa for generative Skills.
-    - http://open-squad for open-retrieval Skills.
-- Skill arguments. Here you need to provide a json that specifies the base model (a Transformer model) and the [adapters](https://adapterhub.ml) to use
- ``` 
- {"base_model": "....", "adapter": ...}
- ```    
-For example:
- ```
-{"base_model":"bert-base-uncased","adapter":"AdapterHub/bert-base-uncased-pf-squad"}
- ```
-
-<details>
-  <summary>Screenshot</summary>
-  <div>
-    <div>Adding a skill via the UI.</div>
-    <br/>
-      <div style={{textAlign:'center'}}>
-      <img
-      src={require('../../static/img/Skill_example.png').default}
-      alt="skill-manager"
-      width="600"
-      height="600"
-    />
-        </div>
-  </div>
-</details>
-
-In the case of open-domain Skills, you also need to specify the datastore and retrieval method as follows:
-```
- {"base_model": "....", "adapter": ..., "datastore": ..., "index": ....}
-```
-The default value of ```index``` is ```bm25```, so if you want to use BM25, you can skip that argument.
-For example:
-```
-{"base_model":"roberta-base","adapter":"AdapterHub/roberta-base-pf-hotpotqa","datastore":"nq","index":"dpr"}
-```
-
-You should mark ```require context``` if the Skill needs an input passage along with the question, and ```public``` if you wan it to be publicly available.
-
 ### The Predict Function
-If you want to create a new skill that does not follow the previously described QA pipelines, you would only need to implement a predict function. For facilitating this, we provide two packages: [SQuARE-skill-helpers*](https://github.com/UKP-SQuARE/square-skill-helpers) and [SQuARE-skill-api](https://github.com/UKP-SQuARE/square-skill-api). The skill-helpers package facilitates the interaction with other SQuARE services, such as Datastores and Models. The skill-api package wraps the final predict function creating an API that can be accessed by SQuARE. Further, it provides dataclasses (pydantic) for input and output of the predict function.
+To create a new skill, only a predict function needs to be implemented. For facilitating this, we provide three packages: [square-datastore-client](https://github.com/UKP-SQuARE/square-datastore-client), [square-model-client](https://github.com/UKP-SQuARE/square-model-client) and [SQuARE-skill-api](https://github.com/UKP-SQuARE/square-skill-api). The client packages facilitate the interaction with other SQuARE services, such as Datastores and Models. The skill-api package wraps the final predict function creating an API that can be accessed by SQuARE. Further, it provides dataclasses (pydantic) for input and output of the predict function.
 
 As mentioned above mainly a predict function, defining the pipeline needs to be implemented. 
 First, install the required packages:
 ```bash
-pip install square-skill-helpers
-pip install square-skill-api 
+pip install square-datastore-client
+pip install square-model-client
+pip install square-skill-api
 ```
 Next, we can implement the `predict` function:
 ```python3
 
 # import utility classes from `square_skill_api` and `square_skill_helpers`
 from square_skill_api.models import QueryOutput, QueryRequest
-from square_skill_helpers import ModelAPI, DataAPI
+from square_model_client import SQuAREModelClient
+from square_datastore_client import SQuAREDatastoreClient
 
-# create instances of the DataAPI and ModelAPI for interacting 
+# create instances of the SQuAREDatastoreClient and SQuAREModelClient for interacting 
 # with SQuAREs Datastores and Models
-data_api = DataAPI()
-model_api = ModelAPI()
+square_datastore_client = SQuAREDatastoreClient()
+square_model_client = SQuAREModelClient()
 
 # this is the standard input that will be given to every predict function. 
 # See the details in the `square_skill_api` package for all available inputs.
 async def predict(request: QueryRequest) -> QueryOutput:
 
     # Call the Datastores using the `data_api` object
-    data = await data_api(datastore_name="nq", index_name="dpr", query=request.query)
-    context = [d["document"]["text"] for d in data]
-    context_score = [d["score"] for d in data]
+    data_response = await square_datastore_client(datastore_name="nq", index_name="dpr", query=request.query)
+    context = [d["document"]["text"] for d in data_response]
+    context_score = [d["score"] for d in data_response]
 
     # prepare the request to the Model API. For details, see Model API docs 
     model_request = {
@@ -98,7 +46,7 @@ async def predict(request: QueryRequest) -> QueryOutput:
     }
 
     # Call Model using the `model_api` object
-    model_api_output = await model_api(
+    model_response = await square_model_client(
         model_name="bert-base-uncased", 
         pipeline="question-answering", 
         model_request=model_request
@@ -107,7 +55,7 @@ async def predict(request: QueryRequest) -> QueryOutput:
     # return an QueryOutput object created using the 
     # question-answering constructor
     return QueryOutput.from_question_answering(
-        model_api_output=model_api_output,
+        model_api_output=model_response,
         context=context,
         context_score=context_score
     )
@@ -153,10 +101,9 @@ An example repository can also be found at [UKP-SQuARE/cloud-example-azure](http
  | NarrativeQA BART Adapter |  |  | [bart-base](https://huggingface.co/facebook/bart-base) | [narrativeqa](https://huggingface.co/AdapterHub/narrativeqa) | multiple-choice | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/generative-qa/skill.py) | 
  | NewsQA BERT Adapter |  |  | [bert-base-uncased](https://huggingface.co/bert-base-uncased) | [newsqa](https://huggingface.co/AdapterHub/bert-base-uncased-pf-newsqa) | span-extraction | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/extractive-qa/skill.py) | 
  | NewsQA RoBERTa Adapter |  |  | [roberta-base](https://huggingface.co/roberta-base) | [newsqa](https://huggingface.co/AdapterHub/roberta-base-pf-newsqa) | span-extraction | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/extractive-qa/skill.py) | 
- | OpenBioASQ | [BM25](https://www.elastic.co/blog/practical-bm25-part-2-the-bm25-algorithm-and-its-variables) |  [BioASQ8](http://bioasq.org/) | [bert-base-uncased](https://huggingface.co/bert-base-uncased) | [squad_v2](https://huggingface.co/https://huggingface.co/AdapterHub/bert-base-uncased-pf-squad_v2) | span-extraction | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/open-bioasq/skill.py) | 
- | OpenBioASQ-TAS-b | [TAS-B](https://huggingface.co/sentence-transformers/msmarco-distilbert-base-tas-b) |  [BioASQ8](http://bioasq.org/) | [bert-base-uncased](https://huggingface.co/bert-base-uncased) | [squad_v2](https://huggingface.co/https://huggingface.co/AdapterHub/bert-base-uncased-pf-squad_v2) | span-extraction | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/open-bioasq/skill.py) | 
- | OpenSQuAD-DPR | [DPR](https://huggingface.co/facebook/dpr-ctx_encoder-single-nq-base) |  [Wikipedia](https://github.com/facebookresearch/DPR/blob/a31212dc0a54dfa85d8bfa01e1669f149ac832b7/dpr/data/download_data.py#L31) | [bert-base-uncased](https://huggingface.co/bert-base-uncased) | [squad_v2](https://huggingface.co/https://huggingface.co/AdapterHub/bert-base-uncased-pf-squad_v2) | span-extraction | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/open-squad/skill.py) | 
- | OpenSQuAD-TAS-b | [TAS-B](https://huggingface.co/sentence-transformers/msmarco-distilbert-base-tas-b) |  [MS MARCO](https://microsoft.github.io/msmarco/) | [bert-base-uncased](https://huggingface.co/bert-base-uncased) | [squad_v2](https://huggingface.co/https://huggingface.co/AdapterHub/bert-base-uncased-pf-squad_v2) | span-extraction | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/open-extractive-qa/skill.py) | 
+ | OpenBioASQ | [BM25](https://www.elastic.co/blog/practical-bm25-part-2-the-bm25-algorithm-and-its-variables) |  Pubmed | [bert-base-uncased](https://huggingface.co/bert-base-uncased) | [squad_v2](https://huggingface.co/https://huggingface.co/AdapterHub/bert-base-uncased-pf-squad_v2) | span-extraction | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/open-bioasq/skill.py) | 
+ | OpenSQuAD-DPR | [dpr](https://huggingface.co/facebook/dpr-ctx_encoder-single-nq-base) |  Wikipedia | [bert-base-uncased](https://huggingface.co/bert-base-uncased) | [squad_v2](https://huggingface.co/https://huggingface.co/AdapterHub/bert-base-uncased-pf-squad_v2) | span-extraction | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/open-squad/skill.py) | 
+ | OpenSQuAD-TAS-b | [dpr](https://huggingface.co/facebook/dpr-ctx_encoder-single-nq-base) |  Wikipedia | [bert-base-uncased](https://huggingface.co/bert-base-uncased) | [squad_v2](https://huggingface.co/https://huggingface.co/AdapterHub/bert-base-uncased-pf-squad_v2) | span-extraction | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/open-extractive-qa/skill.py) | 
  | QuAIL BERT Adapter |  |  | [bert-base-uncased](https://huggingface.co/bert-base-uncased) | [quail](https://huggingface.co/AdapterHub/bert-base-uncased-pf-quail) | multiple-choice | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/multiple-choice-qa/skill.py) | 
  | QuAIL RoBERTa Adapter |  |  | [roberta-base](https://huggingface.co/roberta-base) | [quail](https://huggingface.co/AdapterHub/roberta-base-pf-quail) | multiple-choice | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/multiple-choice-qa/skill.py) | 
  | QuaRTz RoBERTa Adapter |  |  | [roberta-base](https://huggingface.co/roberta-base) | [quartz](https://huggingface.co/AdapterHub/roberta-base-pf-quartz) | multiple-choice | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/multiple-choice-qa/skill.py) | 
@@ -170,6 +117,5 @@ An example repository can also be found at [UKP-SQuARE/cloud-example-azure](http
  | SQuAD 2.0 RoBERTa Adapter |  |  | [roberta-base](https://huggingface.co/roberta-base) | [squad_v2](https://huggingface.co/AdapterHub/roberta-base-pf-squad_v2) | span-extraction | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/extractive-qa/skill.py) | 
  | Social-IQA BERT Adapter |  |  | [bert-base-uncased](https://huggingface.co/bert-base-uncased) | [social_i_qa](https://huggingface.co/AdapterHub/bert-base-uncased-pf-social_i_qa) | multiple-choice | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/multiple-choice-qa/skill.py) | 
  | Social-IQA RoBERTa Adapter |  |  | [roberta-base](https://huggingface.co/roberta-base) | [social_i_qa](https://huggingface.co/AdapterHub/roberta-base-pf-social_i_qa) | multiple-choice | [code](https://github.com/UKP-SQuARE/square-core/blob/master/skills/multiple-choice-qa/skill.py) | 
-
 
 

--- a/docs/home/overview/tutorials.md
+++ b/docs/home/overview/tutorials.md
@@ -66,7 +66,7 @@ Now we can start implementing the Skill, in the newly created `skill.py` file. W
 
 - `QueryRequest`: Class holding the input to the Skill from the UI.
 - `QueryOutput`: Class for holding the output of the Skill to the UI.
-- `DataAPI` & `ModelAPI`: Utility classes that facilitate the interaction with SQuARE's Datastores and Models
+- `SQuAREDatastoreClient` & `SQuAREModelClient`: Utility classes that facilitate the interaction with SQuARE's Datastores and Models
 
 ```python
 import logging
@@ -74,12 +74,14 @@ import logging
 from square_skill_api.models.request import QueryRequest
 from square_skill_api.models.prediction import QueryOutput
 
-from square_skill_helpers import DataAPI, ModelAPI
+
+from square_model_client import SQuAREModelClient
+from square_datastore_client import SQuAREDatastoreClient
 
 logger = logging.getLogger(__name__)
 
-model_api = ModelAPI()
-data_api = DataAPI()
+square_model_client = SQuAREModelClient()
+square_datastore_client = SQuAREDatastoreClient()
 ```
 
 ### Predict Function

--- a/skill-manager/logging.conf
+++ b/skill-manager/logging.conf
@@ -17,5 +17,5 @@ formatter = json
 keys = json
 
 [formatter_json]
-class = elk_json_formatter.ElkJsonFormatter
+class = square_elk_json_formatter.ElkJsonFormatter
 

--- a/skill-manager/requirements.txt
+++ b/skill-manager/requirements.txt
@@ -1,5 +1,5 @@
 square-elk-json-formatter==0.0.3
-square-skil-api==0.0.35
+square-skill-api==0.0.35
 square-auth==0.0.9
 uvicorn>=0.15.0
 fastapi>=0.70.0

--- a/skill-manager/requirements.txt
+++ b/skill-manager/requirements.txt
@@ -1,6 +1,6 @@
 square-elk-json-formatter==0.0.3
 square-skill-api==0.0.35
-square-auth==0.0.9
+square-auth==0.0.11
 uvicorn>=0.15.0
 fastapi>=0.70.0
 pydantic>=1.8.2

--- a/skill-manager/requirements.txt
+++ b/skill-manager/requirements.txt
@@ -1,6 +1,6 @@
-git+https://github.com/UKP-SQuARE/elk-json-formatter@v0.0.2
-git+https://github.com/UKP-SQuARE/square-skill-api.git@v0.0.34
-square-auth>=0.0.7
+square-elk-json-formatter==0.0.3
+square-skil-api==0.0.35
+square-auth==0.0.9
 uvicorn>=0.15.0
 fastapi>=0.70.0
 pydantic>=1.8.2

--- a/skills/README.md
+++ b/skills/README.md
@@ -12,8 +12,8 @@ To create a new skill, only a predict function needs to be implemented. For faci
 As mentioned above mainly a predict function, defining the pipeline needs to be implemented. 
 First, install the required packages:
 ```bash
-pip install git+https://github.com/UKP-SQuARE/square-skill-helpers.git@v0.0.9
-pip install git+https://github.com/UKP-SQuARE/square-skill-api.git@v0.0.34  
+pip install square-skill-helpers
+pip install square-skill-api
 ```
 Next, we can implement the `predict` function:
 ```python3

--- a/skills/README.md
+++ b/skills/README.md
@@ -7,12 +7,13 @@ For a list of available skills, see 👉 [Publicly Available Skills](#publicly-a
 
 ## Add New Skills
 ### The Predict Function
-To create a new skill, only a predict function needs to be implemented. For facilitating this, we provide two packages: [SQuARE-skill-helpers*](https://github.com/UKP-SQuARE/square-skill-helpers) and [SQuARE-skill-api](https://github.com/UKP-SQuARE/square-skill-api). The skill-helpers package facilitates the interaction with other SQuARE services, such as Datastores and Models. The skill-api package wraps the final predict function creating an API that can be accessed by SQuARE. Further, it provides dataclasses (pydantic) for input and output of the predict function.
+To create a new skill, only a predict function needs to be implemented. For facilitating this, we provide three packages: [square-datastore-client](https://github.com/UKP-SQuARE/square-datastore-client), [square-model-client](https://github.com/UKP-SQuARE/square-model-client) and [SQuARE-skill-api](https://github.com/UKP-SQuARE/square-skill-api). The client packages facilitate the interaction with other SQuARE services, such as Datastores and Models. The skill-api package wraps the final predict function creating an API that can be accessed by SQuARE. Further, it provides dataclasses (pydantic) for input and output of the predict function.
 
 As mentioned above mainly a predict function, defining the pipeline needs to be implemented. 
 First, install the required packages:
 ```bash
-pip install square-skill-helpers
+pip install square-datastore-client
+pip install square-model-client
 pip install square-skill-api
 ```
 Next, we can implement the `predict` function:
@@ -20,21 +21,22 @@ Next, we can implement the `predict` function:
 
 # import utility classes from `square_skill_api` and `square_skill_helpers`
 from square_skill_api.models import QueryOutput, QueryRequest
-from square_skill_helpers import ModelAPI, DataAPI
+from square_model_client import SQuAREModelClient
+from square_datastore_client import SQuAREDatastoreClient
 
-# create instances of the DataAPI and ModelAPI for interacting 
+# create instances of the SQuAREDatastoreClient and SQuAREModelClient for interacting 
 # with SQuAREs Datastores and Models
-data_api = DataAPI()
-model_api = ModelAPI()
+square_datastore_client = SQuAREDatastoreClient()
+square_model_client = SQuAREModelClient()
 
 # this is the standard input that will be given to every predict function. 
 # See the details in the `square_skill_api` package for all available inputs.
 async def predict(request: QueryRequest) -> QueryOutput:
 
     # Call the Datastores using the `data_api` object
-    data = await data_api(datastore_name="nq", index_name="dpr", query=request.query)
-    context = [d["document"]["text"] for d in data]
-    context_score = [d["score"] for d in data]
+    data_response = await square_datastore_client(datastore_name="nq", index_name="dpr", query=request.query)
+    context = [d["document"]["text"] for d in data_response]
+    context_score = [d["score"] for d in data_response]
 
     # prepare the request to the Model API. For details, see Model API docs 
     model_request = {
@@ -44,7 +46,7 @@ async def predict(request: QueryRequest) -> QueryOutput:
     }
 
     # Call Model using the `model_api` object
-    model_api_output = await model_api(
+    model_response = await square_model_client(
         model_name="bert-base-uncased", 
         pipeline="question-answering", 
         model_request=model_request
@@ -53,7 +55,7 @@ async def predict(request: QueryRequest) -> QueryOutput:
     # return an QueryOutput object created using the 
     # question-answering constructor
     return QueryOutput.from_question_answering(
-        model_api_output=model_api_output,
+        model_api_output=model_response,
         context=context,
         context_score=context_score
     )

--- a/skills/boolq/skill.py
+++ b/skills/boolq/skill.py
@@ -2,11 +2,11 @@ import logging
 
 from square_skill_api.models import QueryOutput, QueryRequest
 
-from square_skill_helpers import ModelAPI
+from square_model_client import SQuAREModelClient
 
 logger = logging.getLogger(__name__)
 
-model_api = ModelAPI()
+square_model_client = SQuAREModelClient()
 
 
 async def predict(request: QueryRequest) -> QueryOutput:
@@ -26,16 +26,16 @@ async def predict(request: QueryRequest) -> QueryOutput:
         "explain_kwargs": explain_kwargs,
         "attack_kwargs": attack_kwargs,
     }
-    model_api_output = await model_api(
+    model_response = await square_model_client(
         model_name=request.skill_args["base_model"],
         pipeline="sequence-classification",
         model_request=model_request,
     )
-    logger.info(f"Model API output:\n{model_api_output}")
+    logger.info(f"Models response:\n{model_response}")
 
     return QueryOutput.from_sequence_classification(
         questions=query,
         answers=["No", "Yes"],
-        model_api_output=model_api_output,
+        model_api_output=model_response,
         context=context,
     )

--- a/skills/commonsense-qa/skill.py
+++ b/skills/commonsense-qa/skill.py
@@ -2,11 +2,11 @@ import logging
 
 from square_skill_api.models import QueryOutput, QueryRequest
 
-from square_skill_helpers import ModelAPI
+from square_model_client import SQuAREModelClient
 
 logger = logging.getLogger(__name__)
 
-model_api = ModelAPI()
+square_model_client = SQuAREModelClient()
 
 
 async def predict(request: QueryRequest) -> QueryOutput:
@@ -26,13 +26,13 @@ async def predict(request: QueryRequest) -> QueryOutput:
     }
     if request.skill_args.get("adapter"):
         model_request["adapter_name"] = request.skill_args["adapter"]
-    model_api_output = await model_api(
+    model_response = await square_model_client(
         model_name=request.skill_args["base_model"],
         pipeline="sequence-classification",
         model_request=model_request,
     )
-    logger.info(f"Model API output:\n{model_api_output}")
+    logger.info(f"Models response:\n{model_response}")
 
     return QueryOutput.from_sequence_classification(
-        questions=query, answers=choices, model_api_output=model_api_output
+        questions=query, answers=choices, model_api_output=model_response
     )

--- a/skills/extractive-qa/skill.py
+++ b/skills/extractive-qa/skill.py
@@ -2,11 +2,12 @@ import logging
 
 from square_skill_api.models import QueryOutput, QueryRequest
 
-from square_skill_helpers import ModelAPI
+from square_model_client import SQuAREModelClient
+
 
 logger = logging.getLogger(__name__)
 
-model_api = ModelAPI()
+square_model_client = SQuAREModelClient()
 
 
 async def predict(request: QueryRequest) -> QueryOutput:
@@ -30,13 +31,13 @@ async def predict(request: QueryRequest) -> QueryOutput:
     if request.skill_args.get("adapter"):
         model_request["adapter_name"] = request.skill_args["adapter"]
 
-    model_api_output = await model_api(
+    model_response = await square_model_client(
         model_name=request.skill_args["base_model"],
         pipeline="question-answering",
         model_request=model_request,
     )
-    logger.info(f"Model API output:\n{model_api_output}")
+    logger.info(f"Model response:\n{model_response}")
 
     return QueryOutput.from_question_answering(
-        questions=query, model_api_output=model_api_output, context=context
+        questions=query, model_api_output=model_response, context=context
     )

--- a/skills/generative-qa/skill.py
+++ b/skills/generative-qa/skill.py
@@ -2,11 +2,11 @@ import logging
 
 from square_skill_api.models import QueryOutput, QueryRequest
 
-from square_skill_helpers import ModelAPI
+from square_model_client import SQuAREModelClient
 
 logger = logging.getLogger(__name__)
 
-model_api = ModelAPI()
+square_model_client = SQuAREModelClient()
 
 
 async def predict(request: QueryRequest) -> QueryOutput:
@@ -38,13 +38,13 @@ async def predict(request: QueryRequest) -> QueryOutput:
     if request.skill_args.get("adapter"):
         model_request["adapter_name"] = request.skill_args["adapter"]
 
-    model_api_output = await model_api(
+    model_response = await square_model_client(
         model_name=request.skill_args["base_model"],
         pipeline="generation",
         model_request=model_request,
     )
-    logger.info(f"Model API output:\n{model_api_output}")
+    logger.info(f"Model response:\n{model_response}")
 
     return QueryOutput.from_generation(
-        questions=query, model_api_output=model_api_output, context=context
+        questions=query, model_api_output=model_response, context=context
     )

--- a/skills/information-retrieval/skill.py
+++ b/skills/information-retrieval/skill.py
@@ -2,13 +2,11 @@ import logging
 import numpy as np
 
 from square_skill_api.models import QueryOutput, QueryRequest
-
-from square_skill_helpers import DataAPI, ModelAPI
+from square_datastore_client import SQuAREDatastoreClient
 
 logger = logging.getLogger(__name__)
 
-model_api = ModelAPI()
-data_api = DataAPI()
+square_datastore_client = SQuAREDatastoreClient()
 
 
 def softmax(x):
@@ -24,7 +22,7 @@ async def predict(request: QueryRequest) -> QueryOutput:
     if "feedback_documents" in request.skill_args:
         feedback_docs = request.skill_args["feedback_documents"]
         query = request.query
-        data = await data_api(
+        data_response = await square_datastore_client(
             datastore_name=request.skill_args["datastore"],
             index_name=request.skill_args.get("index", ""),
             query=query,
@@ -32,7 +30,7 @@ async def predict(request: QueryRequest) -> QueryOutput:
         )
     else:
         query = request.query
-        data = await data_api(
+        data_response = await square_datastore_client(
             datastore_name=request.skill_args["datastore"],
             index_name=request.skill_args.get("index", ""),
             query=query
@@ -40,14 +38,14 @@ async def predict(request: QueryRequest) -> QueryOutput:
     
     context = []
     if request.skill_args["datastore"] == "bioasq":
-        for d in data:
+        for d in data_response:
             pubmed_url = f"https://pubmed.ncbi.nlm.nih.gov/{d['id']}"
             d["document"]["text"] = f"""{d["document"]["text"]} <p><a href="{pubmed_url}" target="_blank">{pubmed_url}</a></p>"""
             context.append(d["document"]["text"])
     else:
-        context = [d["document"]["text"] for d in data]
+        context = [d["document"]["text"] for d in data_response]
     
-    context_score = [d["score"] for d in data]
+    context_score = [d["score"] for d in data_response]
     context_score = softmax(context_score).round(2).tolist()
 
     return QueryOutput.from_information_retrieval(

--- a/skills/logging.conf
+++ b/skills/logging.conf
@@ -17,5 +17,5 @@ formatter = json
 keys = json
 
 [formatter_json]
-class = elk_json_formatter.ElkJsonFormatter
+class = square_elk_json_formatter.ElkJsonFormatter
 

--- a/skills/open-extractive-qa/skill.py
+++ b/skills/open-extractive-qa/skill.py
@@ -3,12 +3,13 @@ from typing import Iterable
 
 from square_skill_api.models import QueryOutput, QueryRequest
 
-from square_skill_helpers import DataAPI, ModelAPI
+from square_model_client import SQuAREModelClient
+from square_datastore_client import SQuAREDatastoreClient
 
 logger = logging.getLogger(__name__)
 
-model_api = ModelAPI()
-data_api = DataAPI()
+square_model_client = SQuAREModelClient()
+square_datastore_client = SQuAREDatastoreClient()
 
 
 async def predict(request: QueryRequest) -> QueryOutput:
@@ -23,14 +24,14 @@ async def predict(request: QueryRequest) -> QueryOutput:
 
     context = request.skill_args.get("context")
     if not context:
-        data = await data_api(
+        data_response = await square_datastore_client(
             datastore_name=request.skill_args["datastore"],
             index_name=request.skill_args.get("index", ""),
             query=query,
         )
-        logger.info(f"Data API output:\n{data}")
-        context = [d["document"]["text"] for d in data]
-        context_score = [d["score"] for d in data]
+        logger.info(f"Data response:\n{data_response}")
+        context = [d["document"]["text"] for d in data_response]
+        context_score = [d["score"] for d in data_response]
 
         prepared_input = [[query, c] for c in context]
     else:
@@ -46,16 +47,16 @@ async def predict(request: QueryRequest) -> QueryOutput:
     }
     if request.skill_args.get("adapter"):
         model_request["adapter_name"] = request.skill_args["adapter"]
-    model_api_output = await model_api(
+    model_response = await square_model_client(
         model_name=request.skill_args["base_model"],
         pipeline="question-answering",
         model_request=model_request,
     )
-    logger.info(f"Model API output:\n{model_api_output}")
+    logger.info(f"Model response:\n{model_response}")
 
     return QueryOutput.from_question_answering(
         questions=query,
-        model_api_output=model_api_output,
+        model_api_output=model_response,
         context=context,
         context_score=context_score,
     )

--- a/skills/qa-gnn/skill.py
+++ b/skills/qa-gnn/skill.py
@@ -14,7 +14,7 @@ async def predict(request: QueryRequest) -> QueryOutput:
     query = request.query
     # HACK: the UI currently does not support choices, therefore the first choice will
     # be processed insde the context.
-    choices = [request.skill_args["context"]] + request.skill_args["choices"]
+    choices = request.skill_args["choices"]
     model_kwargs = request.skill_args.get("model_kwargs", {})
     model_kwargs["output_lm_subgraph"] = model_kwargs.get("output_lm_subgraph", True)
     model_kwargs["output_attn_subgraph"] = model_kwargs.get(

--- a/skills/qa-gnn/skill.py
+++ b/skills/qa-gnn/skill.py
@@ -2,11 +2,11 @@ import logging
 
 from square_skill_api.models import QueryOutput, QueryRequest
 
-from square_skill_helpers import ModelAPI
+from square_model_client import SQuAREModelClient
 
 logger = logging.getLogger(__name__)
 
-model_api = ModelAPI()
+square_model_client = SQuAREModelClient()
 
 
 async def predict(request: QueryRequest) -> QueryOutput:
@@ -35,13 +35,13 @@ async def predict(request: QueryRequest) -> QueryOutput:
     }
     logger.debug("Request for model api:{}".format(model_request))
 
-    model_api_output = await model_api(
+    model_response = await square_model_client(
         model_name="qagnn",
         pipeline="sequence-classification",
         model_request=model_request,
     )
-    logger.info("Model API output: {}".format(model_api_output))
+    logger.info("Model response: {}".format(model_response))
 
     return QueryOutput.from_sequence_classification_with_graph(
-        questions=query, answers=choices, model_api_output=model_api_output
+        questions=query, answers=choices, model_api_output=model_response
     )

--- a/skills/requirements.txt
+++ b/skills/requirements.txt
@@ -1,3 +1,4 @@
 square-elk-json-formatter==0.0.3
-square-skill-helpers==0.0.10
+square-datastore-client==0.0.1
+square-model-client==0.0.1
 square-skill-api==0.0.35

--- a/skills/requirements.txt
+++ b/skills/requirements.txt
@@ -1,4 +1,4 @@
 square-elk-json-formatter==0.0.3
 square-datastore-client==0.0.1
-square-model-client==0.0.1
+square-model-client==0.0.2
 square-skill-api==0.0.35

--- a/skills/requirements.txt
+++ b/skills/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/UKP-SQuARE/elk-json-formatter.git@v0.0.2
-git+https://github.com/UKP-SQuARE/square-skill-helpers.git@v0.0.9
-git+https://github.com/UKP-SQuARE/square-skill-api.git@v0.0.34
+square-elk-json-formatter==0.0.3
+square-skill-helpers==0.0.10
+square-skill-api==0.0.35

--- a/square-model-inference-api/inference_server/dockerfiles/graph_transformer/requirements1.txt
+++ b/square-model-inference-api/inference_server/dockerfiles/graph_transformer/requirements1.txt
@@ -12,5 +12,5 @@ redis==4.1.4
 pytest-env==0.6.2
 networkx
 spacy>=3.0.0,<4.0.0
+square-elk-json-formatter==0.0.3
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz#egg=en_core_web_sm
-git+https://github.com/UKP-SQuARE/elk-json-formatter@v0.0.2    # ELK logger

--- a/square-model-inference-api/inference_server/dockerfiles/graph_transformer/requirements1.txt
+++ b/square-model-inference-api/inference_server/dockerfiles/graph_transformer/requirements1.txt
@@ -6,7 +6,7 @@ sentencepiece==0.1.96           # tokenizer
 torch==1.11.0                   # pytorch libs
 sentence-transformers==1.2.0    # sentence transformers libs
 onnxruntime==1.12.0             # onnx inference and models
-square-auth>=0.0.7              # keycloak authentication
+square-auth>=0.0.11             # keycloak authentication
 celery==5.1.2                   # queue requests
 redis==4.1.4
 pytest-env==0.6.2

--- a/square-model-inference-api/inference_server/dockerfiles/onnx/requirements1.txt
+++ b/square-model-inference-api/inference_server/dockerfiles/onnx/requirements1.txt
@@ -10,5 +10,5 @@ celery==5.1.2                   # queue requests
 redis==4.1.4
 pytest-env==0.6.2
 spacy>=3.0.0,<4.0.0
+square-elk-json-formatter==0.0.3
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz#egg=en_core_web_sm
-git+https://github.com/UKP-SQuARE/elk-json-formatter@v0.0.2    # ELK logger

--- a/square-model-inference-api/inference_server/dockerfiles/onnx/requirements1.txt
+++ b/square-model-inference-api/inference_server/dockerfiles/onnx/requirements1.txt
@@ -5,7 +5,7 @@ python-dotenv==0.17.1           # Required for .env configs
 sentencepiece==0.1.96           # tokenizer
 torch==1.11.0                   # pytorch libs
 onnxruntime==1.12.0             # onnx inference and models
-square-auth>=0.0.7              # keycloak authentication
+square-auth>=0.0.11             # keycloak authentication
 celery==5.1.2                   # queue requests
 redis==4.1.4
 pytest-env==0.6.2

--- a/square-model-inference-api/inference_server/dockerfiles/sentence_transformer/requirements1.txt
+++ b/square-model-inference-api/inference_server/dockerfiles/sentence_transformer/requirements1.txt
@@ -5,7 +5,7 @@ python-dotenv==0.17.1           # Required for .env configs
 sentencepiece==0.1.96           # tokenizer
 torch==1.11.0                   # pytorch libs
 sentence-transformers==1.2.0    # sentence transformers libs
-square-auth>=0.0.7              # keycloak authentication
+square-auth>=0.0.11             # keycloak authentication
 celery==5.1.2                   # queue requests
 redis==4.1.4
 pytest-env==0.6.2

--- a/square-model-inference-api/inference_server/dockerfiles/sentence_transformer/requirements1.txt
+++ b/square-model-inference-api/inference_server/dockerfiles/sentence_transformer/requirements1.txt
@@ -10,5 +10,5 @@ celery==5.1.2                   # queue requests
 redis==4.1.4
 pytest-env==0.6.2
 spacy>=3.0.0,<4.0.0
+square-elk-json-formatter==0.0.3    
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz#egg=en_core_web_sm
-git+https://github.com/UKP-SQuARE/elk-json-formatter@v0.0.2    # ELK logger

--- a/square-model-inference-api/inference_server/dockerfiles/transformer/requirements1.txt
+++ b/square-model-inference-api/inference_server/dockerfiles/transformer/requirements1.txt
@@ -9,5 +9,5 @@ celery==5.1.2                   # queue requests
 redis==4.1.4
 pytest-env==0.6.2
 spacy>=3.0.0,<4.0.0
+square-elk-json-formatter==0.0.3
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz#egg=en_core_web_sm
-git+https://github.com/UKP-SQuARE/elk-json-formatter@v0.0.2    # ELK logger

--- a/square-model-inference-api/inference_server/dockerfiles/transformer/requirements1.txt
+++ b/square-model-inference-api/inference_server/dockerfiles/transformer/requirements1.txt
@@ -4,7 +4,7 @@ pydantic==1.8.2                 # Input/ output modelling
 python-dotenv==0.17.1           # Required for .env configs
 sentencepiece==0.1.96           # tokenizer
 torch==1.11.0                   # pytorch libs
-square-auth>=0.0.7              # keycloak authentication
+square-auth>=0.0.11             # keycloak authentication
 celery==5.1.2                   # queue requests
 redis==4.1.4
 pytest-env==0.6.2

--- a/square-model-inference-api/inference_server/logging.conf
+++ b/square-model-inference-api/inference_server/logging.conf
@@ -17,4 +17,4 @@ formatter = json
 keys = json
 
 [formatter_json]
-class = elk_json_formatter.ElkJsonFormatter
+class = square_elk_json_formatter.ElkJsonFormatter

--- a/square-model-inference-api/inference_server/requirements1.txt
+++ b/square-model-inference-api/inference_server/requirements1.txt
@@ -12,6 +12,6 @@ redis==4.1.4
 pytest-env==0.6.2
 networkx
 spacy>=3.0.0,<4.0.0
+square-elk-json-formatter==0.0.3
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz#egg=en_core_web_sm
-git+https://github.com/UKP-SQuARE/elk-json-formatter@v0.0.2    # ELK logger
 importlib-metadata<5.0 # https://github.com/celery/celery/issues/7783

--- a/square-model-inference-api/inference_server/requirements1.txt
+++ b/square-model-inference-api/inference_server/requirements1.txt
@@ -6,7 +6,7 @@ sentencepiece==0.1.96           # tokenizer
 torch==1.11.0                   # pytorch libs
 sentence-transformers==1.2.0    # sentence transformers libs
 onnxruntime==1.12.0             # onnx inference and models
-square-auth>=0.0.7              # keycloak authentication
+square-auth>=0.0.11             # keycloak authentication
 celery==5.1.2                   # queue requests
 redis==4.1.4
 pytest-env==0.6.2

--- a/square-model-inference-api/management_server/dev-requirements.txt
+++ b/square-model-inference-api/management_server/dev-requirements.txt
@@ -11,7 +11,7 @@ fastapi>=0.75.0                 # REST API Framework
 pydantic==1.9.0                 # models
 requests>=2.26.0                # requests
 docker                          # docker client
-square-auth>=0.0.7              # keycloak authentication
+square-auth>=0.0.11             # keycloak authentication
 celery==5.2.3                   # queue requests
 redis==4.2.0
 pymongo>=3.12.1

--- a/square-model-inference-api/management_server/dev-requirements.txt
+++ b/square-model-inference-api/management_server/dev-requirements.txt
@@ -15,4 +15,4 @@ square-auth>=0.0.7              # keycloak authentication
 celery==5.2.3                   # queue requests
 redis==4.2.0
 pymongo>=3.12.1
-git+https://github.com/UKP-SQuARE/elk-json-formatter@v0.0.2    # elk-json logger
+square-elk-json-formatter==0.0.3

--- a/square-model-inference-api/management_server/logging.conf
+++ b/square-model-inference-api/management_server/logging.conf
@@ -17,4 +17,4 @@ formatter = json
 keys = json
 
 [formatter_json]
-class = elk_json_formatter.ElkJsonFormatter
+class = square_elk_json_formatter.ElkJsonFormatter

--- a/square-model-inference-api/management_server/requirements.txt
+++ b/square-model-inference-api/management_server/requirements.txt
@@ -3,7 +3,7 @@ fastapi>=0.73.0                 # REST API Framework
 pydantic==1.8.2                 # models
 requests>=2.26.0                # requests
 docker                          # docker client
-square-auth>=0.0.7              # keycloak authentication
+square-auth>=0.0.11             # keycloak authentication
 celery==5.1.2                   # queue requests
 redis==4.1.4
 pymongo>=3.12.1

--- a/square-model-inference-api/management_server/requirements.txt
+++ b/square-model-inference-api/management_server/requirements.txt
@@ -7,5 +7,5 @@ square-auth>=0.0.7              # keycloak authentication
 celery==5.1.2                   # queue requests
 redis==4.1.4
 pymongo>=3.12.1
-git+https://github.com/UKP-SQuARE/elk-json-formatter@v0.0.2    # elk-json logger
+square-elk-json-formatter==0.0.3
 importlib-metadata<5.0 # https://github.com/celery/celery/issues/7783


### PR DESCRIPTION
# What does this PR do?
Previously, square libraries like square-auth have been installed from git releases. Now, we install them directly from pypi.

Deprecates the `square-skill-helpers`. From this PR, the model and datastore client a separate packages.