### PR TITLE
CI: Login to Dockerhub step only on master

### DIFF
--- a/.github/workflows/ci-datastore-api.yml
+++ b/.github/workflows/ci-datastore-api.yml
@@ -90,6 +90,7 @@ jobs:
           fail_on_failure: true
 
       - name: Login to Docker Hub
+        if: ${{github.ref == 'refs/heads/master'}}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -42,6 +42,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to Docker Hub
+        if: ${{github.ref == 'refs/heads/master'}}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -42,6 +42,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to Docker Hub
+        if: ${{github.ref == 'refs/heads/master'}}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/ci-model-api.yml
+++ b/.github/workflows/ci-model-api.yml
@@ -174,6 +174,7 @@ jobs:
           fail_on_failure: true
 
       - name: Login to Docker Hub
+        if: ${{github.ref == 'refs/heads/master'}}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/ci-model-api.yml
+++ b/.github/workflows/ci-model-api.yml
@@ -81,6 +81,7 @@ jobs:
           fail_on_failure: true
 
       - name: Login to Docker Hub
+        if: ${{github.ref == 'refs/heads/master'}}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/ci-skill-manager.yml
+++ b/.github/workflows/ci-skill-manager.yml
@@ -71,6 +71,7 @@ jobs:
           path: ${{ github.workspace }}/skill-manager/test-reports
 
       - name: Login to Docker Hub
+        if: ${{github.ref == 'refs/heads/master'}}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/ci-skills.yml
+++ b/.github/workflows/ci-skills.yml
@@ -73,6 +73,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to Docker Hub
+        if: ${{github.ref == 'refs/heads/master'}}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
# What does this PR do?
In the CI pipelines, login to Docker Hub is only required when the pipeline is triggered on the master branch. We want to skip the login in all other cases to allow outside contributors (i.e. via fork and PR) to able to run the CI without using repository secrets (dockerhub username and password in this case).


