### PR TITLE
check model_name among current tasks iff task['name] is deploy_task

### DIFF
--- a/skill-manager/skill_manager/core/model_management_client.py
+++ b/skill-manager/skill_manager/core/model_management_client.py
@@ -99,9 +99,10 @@ class ModelManagementClient:
         for worker2tasks in running_tasks.values():
             for tasks in worker2tasks.values():
                 for task in tasks:
-                    model_name = task["args"][0]["MODEL_NAME"]
-                    model_type = task["args"][0]["MODEL_TYPE"]
-                    models_in_deployment[model_name] = model_type
+                    if task["name"] == "tasks.tasks.deploy_task":
+                        model_name = task["args"][0]["MODEL_NAME"]
+                        model_type = task["args"][0]["MODEL_TYPE"]
+                        models_in_deployment[model_name] = model_type
 
         return models_in_deployment
 


### PR DESCRIPTION
the deployment of models through the UI (i.e., creating a skill) is not working.
![image](https://user-images.githubusercontent.com/2658728/208103854-0b372302-6d43-4616-be4b-b5a5f1c0ef2f.png)
this generates this error
![image](https://user-images.githubusercontent.com/2658728/208103896-d676d07f-c702-4eaa-838b-a2b4b7a2fc40.png)

I think when we check among deploying tasks, we always assume the tasks are deploying models, but this is not always the case, there might be other tasks running