### PR TITLE
Pass all kwargs to models

### DIFF
--- a/evaluator/requirements.txt
+++ b/evaluator/requirements.txt
@@ -1,5 +1,5 @@
 square-elk-json-formatter==0.0.3
-square-skill-api==0.0.35
+square-skill-api==0.0.37
 square-auth==0.0.14
 uvicorn>=0.15.0
 fastapi>=0.70.0

--- a/skill-manager/requirements.txt
+++ b/skill-manager/requirements.txt
@@ -1,5 +1,5 @@
 square-elk-json-formatter==0.0.3
-square-skill-api==0.0.35
+square-skill-api==0.0.37
 square-auth==0.0.14
 uvicorn>=0.15.0
 fastapi>=0.70.0

--- a/skill-manager/skill_manager/models.py
+++ b/skill-manager/skill_manager/models.py
@@ -65,7 +65,7 @@ class Skill(MongoModel):
         description="A description of the skill, for example describing its pipeline.",
     )
     default_skill_args: Optional[Dict] = Field(
-        None,
+        {},
         description="A dictionary holding key-value pairs that should always be sent to the skill as input. This allows to use the same skill implementataion in different ways.",
     )
     published: bool = Field(

--- a/skill-manager/skill_manager/routers/skill.py
+++ b/skill-manager/skill_manager/routers/skill.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from threading import Thread
 from typing import Dict, List
 
-import requests_cache
 from bson import ObjectId
 from fastapi import APIRouter, Depends, Request
 from square_auth.auth import Auth
@@ -25,6 +24,7 @@ from skill_manager.core.session_cache import SessionCache
 from skill_manager.keycloak_api import KeycloakAPI
 from skill_manager.models import Prediction, Skill, SkillType
 from skill_manager.routers import client_credentials
+from skill_manager.utils import merge_dicts
 
 logger = logging.getLogger(__name__)
 
@@ -236,13 +236,29 @@ async def query_skill(
     query = query_request.query
     user_id = query_request.user_id
 
-    skill = await get_skill_if_authorized(request, skill_id=id, write_access=False)
+    skill: Skill = await get_skill_if_authorized(
+        request, skill_id=id, write_access=False
+    )
     query_request.skill = json.loads(skill.json())
 
-    default_skill_args = skill.default_skill_args
-    if default_skill_args is not None:
-        # add default skill args, potentially overwrite with query.skill_args
-        query_request.skill_args = {**default_skill_args, **query_request.skill_args}
+    # merge kargs with kwargs in request
+    for kwargs_key in [
+        "model_kwargs",
+        "task_kwargs",
+        "preprocessing_kwargs",
+        "explain_kwargs",
+        "attack_kwargs",
+    ]:
+        # overwrite kwargs from query_request with default kwargs
+        kwargs = merge_dicts(
+            skill.default_skill_args.pop(kwargs, {}), getattr(query_request, kwargs)
+        )
+        # set kwargs in query_request
+        setattr(query_request, kwargs_key, kwargs)
+
+    query_request.skill_args = merge_dicts(
+        skill.default_skill_args, query_request.skill_args
+    )
 
     headers = {"Authorization": f"Bearer {token}"}
     if request.headers.get("Cache-Control"):

--- a/skill-manager/skill_manager/routers/skill.py
+++ b/skill-manager/skill_manager/routers/skill.py
@@ -251,7 +251,8 @@ async def query_skill(
     ]:
         # overwrite kwargs from query_request with default kwargs
         kwargs = merge_dicts(
-            skill.default_skill_args.pop(kwargs, {}), getattr(query_request, kwargs)
+            skill.default_skill_args.pop(kwargs_key, {}),
+            getattr(query_request, kwargs_key),
         )
         # set kwargs in query_request
         setattr(query_request, kwargs_key, kwargs)

--- a/skill-manager/skill_manager/routers/skill.py
+++ b/skill-manager/skill_manager/routers/skill.py
@@ -256,7 +256,6 @@ async def query_skill(
         )
         # set kwargs in query_request
         setattr(query_request, kwargs_key, kwargs)
-
     query_request.skill_args = merge_dicts(
         skill.default_skill_args, query_request.skill_args
     )

--- a/skill-manager/skill_manager/utils.py
+++ b/skill-manager/skill_manager/utils.py
@@ -1,0 +1,6 @@
+def merge_dicts(**dicts):
+    """Merge multiple dictionaries into one. Overwrites values from left to right."""
+    merged = {}
+    for d in dicts:
+        merged.update(d)
+    return merged

--- a/skill-manager/skill_manager/utils.py
+++ b/skill-manager/skill_manager/utils.py
@@ -1,4 +1,4 @@
-def merge_dicts(**dicts):
+def merge_dicts(*dicts):
     """Merge multiple dictionaries into one. Overwrites values from left to right."""
     merged = {}
     for d in dicts:

--- a/skill-manager/tests/conftest.py
+++ b/skill-manager/tests/conftest.py
@@ -92,7 +92,7 @@ def skill_factory():
             user_id=user_id,
             description=description,
             published=published,
-            default_skill_args=default_skill_args,
+            default_skill_args={} if default_skill_args is None else default_skill_args,
             **kwargs,
         )
         if not skill.id:

--- a/skill-manager/tests/test_utils.py
+++ b/skill-manager/tests/test_utils.py
@@ -1,0 +1,13 @@
+from skill_manager.utils import merge_dicts
+
+def test_merge_dicts():
+    d1 = {"a": 1}
+    d2 = {"b": 2}
+    merged_dicts = merge_dicts(d1, d2)
+    assert merged_dicts == {"a": 1, "b": 2}
+
+def test_overwrite_merge_dicts():
+    d1 = {"a": 1}
+    d2 = {"a": 2}
+    merged_dicts = merge_dicts(d1, d2)
+    assert merged_dicts == {"a": 2}

--- a/skill-manager/tests/test_utils.py
+++ b/skill-manager/tests/test_utils.py
@@ -1,10 +1,12 @@
 from skill_manager.utils import merge_dicts
 
+
 def test_merge_dicts():
     d1 = {"a": 1}
     d2 = {"b": 2}
     merged_dicts = merge_dicts(d1, d2)
     assert merged_dicts == {"a": 1, "b": 2}
+
 
 def test_overwrite_merge_dicts():
     d1 = {"a": 1}

--- a/skills/Dockerfile
+++ b/skills/Dockerfile
@@ -12,6 +12,7 @@ COPY requirements.txt ./
 RUN pip install -r requirements.txt
 
 COPY main.py main.py
+COPY utils.py utils.py
 ARG skill
 COPY ./$skill/skill.py skill.py 
 COPY logging.conf logging.conf

--- a/skills/boolq/skill.py
+++ b/skills/boolq/skill.py
@@ -3,6 +3,8 @@ import logging
 from square_model_client import SQuAREModelClient
 from square_skill_api.models import QueryOutput, QueryRequest
 
+from utils import extract_model_kwargs_from_request
+
 logger = logging.getLogger(__name__)
 
 square_model_client = SQuAREModelClient()
@@ -12,18 +14,15 @@ async def predict(request: QueryRequest) -> QueryOutput:
     """Predicts yes/no for a boolean question with context"""
     query = request.query
     context = request.skill_args["context"]
-    explain_kwargs = request.explain_kwargs or {}
-    attack_kwargs = request.attack_kwargs or {}
+
+    model_request_kwargs = extract_model_kwargs_from_request(request)
 
     prepared_input = [[context, query]]
 
     model_request = {
         "input": prepared_input,
-        "preprocessing_kwargs": {},
-        "model_kwargs": {},
         "adapter_name": request.skill_args["adapter"],
-        "explain_kwargs": explain_kwargs,
-        "attack_kwargs": attack_kwargs,
+        **model_request_kwargs,
     }
     model_response = await square_model_client(
         model_name=request.skill_args["base_model"],

--- a/skills/commonsense-qa/skill.py
+++ b/skills/commonsense-qa/skill.py
@@ -3,6 +3,8 @@ import logging
 from square_model_client import SQuAREModelClient
 from square_skill_api.models import QueryOutput, QueryRequest
 
+from utils import extract_model_kwargs_from_request
+
 logger = logging.getLogger(__name__)
 
 square_model_client = SQuAREModelClient()
@@ -15,14 +17,9 @@ async def predict(request: QueryRequest) -> QueryOutput:
     choices = request.skill_args["choices"]
     prepared_input = [[query, c] for c in choices]
 
-    explain_kwargs = request.explain_kwargs or {}
-    attack_kwargs = request.attack_kwargs or {}
+    model_request_kwargs = extract_model_kwargs_from_request(request)
 
-    model_request = {
-        "input": prepared_input,
-        "explain_kwargs": explain_kwargs,
-        "attack_kwargs": attack_kwargs,
-    }
+    model_request = {"input": prepared_input, **model_request_kwargs}
     if request.skill_args.get("adapter"):
         model_request["adapter_name"] = request.skill_args["adapter"]
     model_response = await square_model_client(

--- a/skills/extractive-qa/skill.py
+++ b/skills/extractive-qa/skill.py
@@ -26,11 +26,9 @@ async def predict(request: QueryRequest) -> QueryOutput:
     model_request = {"input": prepared_input, **model_request_kwargs}
 
     if request.skill_args.get("adapter"):
+        model_request["adapter_name"] = request.skill_args["adapter"]
         if request.skill_args.get("average_adapters"):
-            model_request["adapter_name"] = request.skill_args["adapter"]
-            model_request["model_kwargs"]['average_adapters'] = True
-        else:
-            model_request["adapter_name"] = request.skill_args["adapter"]
+            model_request["model_kwargs"]["average_adapters"] = True
 
     model_response = await square_model_client(
         model_name=request.skill_args["base_model"],

--- a/skills/extractive-qa/skill.py
+++ b/skills/extractive-qa/skill.py
@@ -3,6 +3,8 @@ import logging
 from square_model_client import SQuAREModelClient
 from square_skill_api.models import QueryOutput, QueryRequest
 
+from utils import extract_model_kwargs_from_request
+
 logger = logging.getLogger(__name__)
 
 square_model_client = SQuAREModelClient()
@@ -17,18 +19,12 @@ async def predict(request: QueryRequest) -> QueryOutput:
 
     query = request.query
     context = request.skill_args["context"]
-    explain_kwargs = request.explain_kwargs or {}
-    attack_kwargs = request.attack_kwargs or {}
     prepared_input = [[query, context]]
-    model_request = {
-        "input": prepared_input,
-        "task_kwargs": {
-            "topk": request.skill_args.get("topk", 5),
-            "show_null_answers": request.skill_args.get("show_null_answers", True),
-        },
-        "explain_kwargs": explain_kwargs,
-        "attack_kwargs": attack_kwargs,
-    }
+
+    model_request_kwargs = extract_model_kwargs_from_request(request)
+
+    model_request = {"input": prepared_input, **model_request_kwargs}
+
     if request.skill_args.get("adapter"):
         if request.skill_args.get("average_adapters"):
             model_request["adapter_name"] = request.skill_args["adapter"]

--- a/skills/generative-qa/skill.py
+++ b/skills/generative-qa/skill.py
@@ -3,6 +3,8 @@ import logging
 from square_model_client import SQuAREModelClient
 from square_skill_api.models import QueryOutput, QueryRequest
 
+from utils import extract_model_kwargs_from_request
+
 logger = logging.getLogger(__name__)
 
 square_model_client = SQuAREModelClient()
@@ -17,23 +19,20 @@ async def predict(request: QueryRequest) -> QueryOutput:
 
     query = request.query
     context = request.skill_args.get("context", "")
-    explain_kwargs = request.explain_kwargs or {}
-    attack_kwargs = request.attack_kwargs or {}
 
     if context:
         query_context_seperator = request.skill_args.get("query_context_seperator", " ")
         prepared_input = [query + query_context_seperator + context]
     else:
         prepared_input = [query]
-    model_request = {
-        "input": prepared_input,
-        "model_kwargs": {
-            "output_scores": True,
-            **request.skill_args.get("model_kwargs", {}),
-        },
-        "explain_kwargs": explain_kwargs,
-        "attack_kwargs": attack_kwargs,
-    }
+
+    model_request_kwargs = extract_model_kwargs_from_request(request)
+    output_scores = request.skill_args.get("model_kwargs", {}).get(
+        "output_scores", True
+    )
+    model_request_kwargs["model_kwargs"]["output_scores"] = output_scores
+
+    model_request = {"input": prepared_input, **model_request_kwargs}
     if request.skill_args.get("adapter"):
         model_request["adapter_name"] = request.skill_args["adapter"]
 

--- a/skills/multiple-choice-qa/skill.py
+++ b/skills/multiple-choice-qa/skill.py
@@ -4,6 +4,8 @@ import uuid
 from square_model_client import SQuAREModelClient
 from square_skill_api.models import QueryOutput, QueryRequest
 
+from utils import extract_model_kwargs_from_request
+
 logger = logging.getLogger(__name__)
 
 square_model_client = SQuAREModelClient()
@@ -18,8 +20,6 @@ async def predict(request: QueryRequest) -> QueryOutput:
     query = request.query
     context = request.skill_args.get("context")
     choices = request.skill_args["choices"]
-    explain_kwargs = request.explain_kwargs or {}
-    attack_kwargs = request.attack_kwargs or {}
 
     if request.skill.get("skill_type") == "categorical":
         # answer choices for categorical skills are hard-coded and not required as
@@ -31,11 +31,10 @@ async def predict(request: QueryRequest) -> QueryOutput:
         else:
             prepared_input = [[context, query + " " + choice] for choice in choices]
 
-    # Call Model API
+    model_request_kwargs = extract_model_kwargs_from_request(request)
     model_request = {
         "input": prepared_input,
-        "explain_kwargs": explain_kwargs,
-        "attack_kwargs": attack_kwargs,
+        **model_request_kwargs,
     }
     if request.skill_args.get("adapter"):
         if request.skill_args.get("average_adapters"):

--- a/skills/multiple-choice-qa/skill.py
+++ b/skills/multiple-choice-qa/skill.py
@@ -37,11 +37,9 @@ async def predict(request: QueryRequest) -> QueryOutput:
         **model_request_kwargs,
     }
     if request.skill_args.get("adapter"):
+        model_request["adapter_name"] = request.skill_args["adapter"]
         if request.skill_args.get("average_adapters"):
-            model_request["adapter_name"] = request.skill_args["adapter"]
-            model_request["model_kwargs"]['average_adapters'] = True
-        else:
-            model_request["adapter_name"] = request.skill_args["adapter"]
+            model_request["model_kwargs"]["average_adapters"] = True
 
     logger.debug("Request for model api:{}".format(model_request))
 

--- a/skills/open-extractive-qa/skill.py
+++ b/skills/open-extractive-qa/skill.py
@@ -5,6 +5,8 @@ from square_datastore_client import SQuAREDatastoreClient
 from square_model_client import SQuAREModelClient
 from square_skill_api.models import QueryOutput, QueryRequest
 
+from utils import extract_model_kwargs_from_request
+
 logger = logging.getLogger(__name__)
 
 square_model_client = SQuAREModelClient()
@@ -18,10 +20,8 @@ async def predict(request: QueryRequest) -> QueryOutput:
     """
 
     query = request.query
-    explain_kwargs = request.explain_kwargs or {}
-    attack_kwargs = request.attack_kwargs or {}
-
     context = request.skill_args.get("context")
+
     if not context:
         data_response = await square_datastore_client(
             datastore_name=request.skill_args["datastore"],
@@ -39,14 +39,11 @@ async def predict(request: QueryRequest) -> QueryOutput:
         prepared_input = [[query, context]]
         context_score = 1
 
-    model_request = {
-        "input": prepared_input,
-        "task_kwargs": {"topk": request.skill_args.get("topk", 5)},
-        "explain_kwargs": explain_kwargs,
-        "attack_kwargs": attack_kwargs,
-    }
+    model_request_kwargs = extract_model_kwargs_from_request(request)
+    model_request = {"input": prepared_input, **model_request_kwargs}
     if request.skill_args.get("adapter"):
         model_request["adapter_name"] = request.skill_args["adapter"]
+
     model_response = await square_model_client(
         model_name=request.skill_args["base_model"],
         pipeline="question-answering",

--- a/skills/qa-gnn/skill.py
+++ b/skills/qa-gnn/skill.py
@@ -3,6 +3,8 @@ import logging
 from square_model_client import SQuAREModelClient
 from square_skill_api.models import QueryOutput, QueryRequest
 
+from utils import extract_model_kwargs_from_request
+
 logger = logging.getLogger(__name__)
 
 square_model_client = SQuAREModelClient()
@@ -11,27 +13,18 @@ square_model_client = SQuAREModelClient()
 async def predict(request: QueryRequest) -> QueryOutput:
 
     query = request.query
-    # HACK: the UI currently does not support choices, therefore the first choice will
-    # be processed insde the context.
     choices = request.skill_args["choices"]
-    model_kwargs = request.skill_args.get("model_kwargs", {})
-    model_kwargs["output_lm_subgraph"] = model_kwargs.get("output_lm_subgraph", True)
-    model_kwargs["output_attn_subgraph"] = model_kwargs.get(
-        "output_attn_subgraph", True
-    )
-
-    explain_kwargs = request.explain_kwargs or {}
-    attack_kwargs = request.attack_kwargs or {}
-
     prepared_input = [[query, choice] for choice in choices]
 
-    # Call Model API
-    model_request = {
-        "input": prepared_input,
-        "model_kwargs": model_kwargs,
-        "explain_kwargs": explain_kwargs,
-        "attack_kwargs": attack_kwargs,
-    }
+    model_request_kwargs = extract_model_kwargs_from_request(request)
+
+    ols_default = model_request_kwargs["model_kwargs"].get("output_lm_subgraph", True)
+    model_request_kwargs["model_kwargs"]["output_lm_subgraph"] = ols_default
+
+    oas_default = model_request_kwargs["model_kwargs"].get("output_attn_subgraph", True)
+    model_request_kwargs["model_kwargs"]["output_attn_subgraph"] = oas_default
+
+    model_request = {"input": prepared_input, **model_request_kwargs}
     logger.debug("Request for model api:{}".format(model_request))
 
     model_response = await square_model_client(

--- a/skills/requirements.txt
+++ b/skills/requirements.txt
@@ -1,4 +1,4 @@
 square-elk-json-formatter==0.0.3
 square-datastore-client==0.0.2
 square-model-client==0.0.3
-square-skill-api==0.0.35
+square-skill-api==0.0.37

--- a/skills/utils.py
+++ b/skills/utils.py
@@ -1,0 +1,15 @@
+from typing import Dict
+
+from square_skill_api.models import QueryRequest
+
+
+def extract_model_kwargs_from_request(request: QueryRequest) -> Dict[str, Dict]:
+    """Extracts the kwargs from a QueryRequest"""
+
+    return {
+        "explain_kwargs": request.explain_kwargs or {},
+        "attack_kwargs": request.attack_kwargs or {},
+        "model_kwargs": request.model_kwargs or {},
+        "task_kwargs": request.task_kwargs or {},
+        "preprocessing_kwargs": request.preprocessing_kwargs or {},
+    }


### PR DESCRIPTION
# What does this PR do?
This PR enables skills to support all kwargs for the model api, including `task_kwargs`, `model_kwargs`, `preprocessing_kwargs`, `explain_kwargs`, `attack_kwargs`. These parameters are no longer supported in the skill_args, but with v0.0.37 of the square-skill-api, are their own field.
