### PR TITLE
Fixed Error for KG tests

### DIFF
--- a/datastore-api/tests/conftest.py
+++ b/datastore-api/tests/conftest.py
@@ -171,7 +171,7 @@ def user_id() -> str:
 def es_container(
     wiki_datastore: Datastore,
     bing_search_datastore: Datastore,
-    conceptnet_kg: Datastore,
+    kg_name: str,
     test_node: Document,
     mongo_container: Tuple[str, str],
     user_id: str,
@@ -211,8 +211,8 @@ def es_container(
                     wiki_datastore.name, query_document.id, query_document
                 )
             ),
-            loop.create_task(kg_connector.add_kg(conceptnet_kg)),
-            loop.create_task(kg_connector.add_document(conceptnet_kg.name,test_node.id, test_node ))
+            loop.create_task(kg_connector.add_kg(kg_name)),
+            loop.create_task(kg_connector.add_document(kg_name,test_node.id, test_node ))            
         ]
         loop.run_until_complete(asyncio.gather(*tasks))
 
@@ -227,7 +227,7 @@ def es_container(
         )
 
         # add conceptnet kg binding
-        datastore_name = conceptnet_kg.name
+        datastore_name = kg_name
         mongo_client = build_mongo_client(*mongo_container)
         mongo_client.user_datastore_bindings.insert_one(
             {


### PR DESCRIPTION
# What does this PR do?
This fixes the error that occur recently on the datastore tests.

Errors:
FAILED tests/test_kgs.py::TestKGs::test_get_all_kgs - AssertionError: assert ...
FAILED tests/test_kgs.py::TestKGs::test_get_conceptnet - AssertionError: asse...
FAILED tests/test_kgs.py::TestKGs::test_put_node - assert 400 == 201
FAILED tests/test_kgs.py::TestKGs::test_put_nodes - assert 400 == 201

Like in these PRs:
https://github.com/UKP-SQuARE/square-core/pull/423
https://github.com/UKP-SQuARE/square-core/pull/360

The main reason for this is the KG format, which was not predefined in the KG-connector. This PR fixes this error.

## Before submitting / marking as 'ready to review'
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [] Did you make sure to update the documentation with your changes?
- [] Did you write any new necessary tests?


