### PR TITLE
Add test_put_kg

### DIFF
--- a/datastore-api/app/core/kgs/connector.py
+++ b/datastore-api/app/core/kgs/connector.py
@@ -54,15 +54,17 @@ class KnowledgeGraphConnector(ElasticsearchConnector):
         Args:
             name (str): Knowledge Graph name to add.
         """
-        kg_predefined = Datastore(name=name,fields=[
-            DatastoreField(name="name", type="keyword"),
-            DatastoreField(name="type", type="keyword"),
-            DatastoreField(name="description", type="text"),
-            DatastoreField(name="weight", type="double"),
-            DatastoreField(name="in_id", type="keyword"),
-            DatastoreField(name="out_id", type="keyword"), 
-        ],
-    )
+        kg_predefined = Datastore(
+            name=name,
+            fields=[
+                DatastoreField(name="name", type="keyword"),
+                DatastoreField(name="type", type="keyword"),
+                DatastoreField(name="description", type="text"),
+                DatastoreField(name="weight", type="double"),
+                DatastoreField(name="in_id", type="keyword"),
+                DatastoreField(name="out_id", type="keyword"), 
+            ],
+        )
         try:
             # The ES index that holds the documents
             resp1 = await self.es.indices.create(


### PR DESCRIPTION
# What does this PR do?
Added a missing test: `test_put_kg`.

Changes:
- `datastore-api/app/core/kgs/connector.py`: Reformat the code
- `datastore-api/app/routers/kgs.py`: Correct the `put_kg` method. It now calls `add_kg` instead of `add_datastore`. And now it can only create a new KG but update an existing KG.
- `datastore-api/tests/test_kgs.py`: Added test_put_kg. In test_get_all_kgs, it now checks whether the preset KG exists.


## Before submitting / marking as 'ready to review'
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

Feel free to tag members/contributors who may be interested in your PR.

<!-- If you don't know exactly who to tag, here is a rough guidline:

- datastores: @kwang2049
- frontend: @HaritzPuerto
- skills: @timbmg
- models: @Rachneet
- docs: @Rachneet

 -->
