### PR TITLE
Set num threads in onnx inference session

### DIFF
--- a/model-inference/model_inference/tasks/inference/onnx.py
+++ b/model-inference/model_inference/tasks/inference/onnx.py
@@ -1,5 +1,7 @@
+import os
 from collections import defaultdict
 from typing import Tuple, Union
+from multiprocessing import cpu_count
 
 import logging
 import numpy as np
@@ -83,6 +85,7 @@ class Onnx(Transformer):
             return model_path
 
         so = onnxruntime.SessionOptions()
+        so.intra_op_num_threads = os.getenv("CPU_COUNT", cpu_count() // 8)
         # enable all graph optimizations
         so.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
 

--- a/model-inference/model_inference/tasks/inference/onnx.py
+++ b/model-inference/model_inference/tasks/inference/onnx.py
@@ -104,7 +104,7 @@ class Onnx(Transformer):
         # load model and create onnx session
         model_path = download_model(repo_id=model_name, filename=filename)
         
-        self.session = onnxruntime.InferenceSession(model_path, )
+        self.session = onnxruntime.InferenceSession(model_path, sess_options=so)
 
         try:
             # load tokenizer from model repository

--- a/model-inference/model_inference/tasks/inference/onnx.py
+++ b/model-inference/model_inference/tasks/inference/onnx.py
@@ -82,6 +82,10 @@ class Onnx(Transformer):
                 raise
             return model_path
 
+        so = onnxruntime.SessionOptions()
+        # enable all graph optimizations
+        so.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
+
         # check whether a decoder model is available
         self.is_encoder_decoder = is_encoder_decoder
         if is_encoder_decoder:
@@ -90,17 +94,14 @@ class Onnx(Transformer):
             decoder = "decoder_model.onnx"
 
             model_path = download_model(repo_id=model_name, filename=decoder)
-            self.decoder_session = onnxruntime.InferenceSession(model_path)
+            self.decoder_session = onnxruntime.InferenceSession(model_path, sess_options=so)
         else:
             filename = "model_quant.onnx" if load_quantized else "model.onnx" 
 
         # load model and create onnx session
         model_path = download_model(repo_id=model_name, filename=filename)
-        self.session = onnxruntime.InferenceSession(model_path)
-
-        # enable all graph optimizations
-        so = onnxruntime.SessionOptions()
-        so.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
+        
+        self.session = onnxruntime.InferenceSession(model_path, )
 
         try:
             # load tokenizer from model repository

--- a/model-inference/model_inference/tasks/inference/onnx.py
+++ b/model-inference/model_inference/tasks/inference/onnx.py
@@ -85,7 +85,7 @@ class Onnx(Transformer):
             return model_path
 
         so = onnxruntime.SessionOptions()
-        so.intra_op_num_threads = os.getenv("CPU_COUNT", cpu_count() // 8)
+        so.intra_op_num_threads = os.getenv("CPU_COUNT", max(1, cpu_count() // 8))
         # enable all graph optimizations
         so.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
 

--- a/model-manager/model_manager/docker_access.py
+++ b/model-manager/model_manager/docker_access.py
@@ -107,7 +107,7 @@ def start_new_model_container(identifier: str, uid: str, env):
 
 
     try:
-        random_cpus = random.sample(list(range(cpu_count())), k=os.getenv("CPU_COUNT", cpu_count() // 8))
+        random_cpus = random.sample(list(range(cpu_count())), k=os.getenv("CPU_COUNT", max(1,cpu_count() // 8)))
         random_cpus = ",".join(map(str, random_cpus))
         cpuset_cpus = env.get("CPUS", random_cpus)
         logger.info(f"Deploying {identifier} using CPUS={cpuset_cpus}")


### PR DESCRIPTION
# What does this PR do?
Make ONNX models compatible with using a subset of CPUs.
1. Fixes bug where SessionOptions were not passed to InferenceSession
2. Sets num threads in session options configurable by `CPU_COUNT` variable.
