### PR TITLE
Add SQUARE_API_URL env var to skill-manager environment

### DIFF
--- a/docker-compose.ytt.yaml
+++ b/docker-compose.ytt.yaml
@@ -224,6 +224,7 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       SQUARE_URL: #@ data.values.square_url[data.values.environment]
+      SQUARE_API_URL: #@ data.values.square_api_url[data.values.environment]
     depends_on:
       - mongodb
       - redis


### PR DESCRIPTION
# What does this PR do?
Fixes Skil-Manager not being able to deploy models because of missing env variable.
