### PR TITLE
Add Portainer Monitoring Service and few Healthchecks

### DIFF
--- a/docker-compose.ytt.yaml
+++ b/docker-compose.ytt.yaml
@@ -77,6 +77,7 @@ services:
       - #@ "--certificatesresolvers.le.acme.email=" + data.values.email
       #@ if/end data.values.environment == "local":
       - --certificatesresolvers.le.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
+      - --ping
     labels:
       - "traefik.enable=true"
       #! Global redirect to https
@@ -98,6 +99,11 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - traefik-public-certificates:/certificates
+    healthcheck:
+      test: traefik healthcheck --ping
+      interval: 20s
+      timeout: 10s
+      retries: 10
 
   keycloak:
     image: jboss/keycloak:16.1.1
@@ -135,6 +141,11 @@ services:
     volumes:
       - db-data:/var/lib/postgresql/data
       - ./postgres/init:/docker-entrypoint-initdb.d/
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 20s
+      timeout: 10s
+      retries: 10
   
   virtuoso:
     image: tenforce/virtuoso:virtuoso7.2.5
@@ -673,6 +684,11 @@ services:
       - #@ template.replace(traefik_tls("dozzle"))
       - traefik.http.routers.dozzle.rule=PathPrefix(`/admin/logs`)
       - traefik.http.routers.dozzle.middlewares=auth
+    healthcheck:
+      test: ["CMD", "/dozzle", "healthcheck"]
+      interval: 20s
+      timeout: 10s
+      retries: 10
 
   portainer:
     image: portainer/portainer-ce:latest

--- a/docker-compose.ytt.yaml
+++ b/docker-compose.ytt.yaml
@@ -674,6 +674,23 @@ services:
       - traefik.http.routers.dozzle.rule=PathPrefix(`/admin/logs`)
       - traefik.http.routers.dozzle.middlewares=auth
 
+  portainer:
+    image: portainer/portainer-ce:latest
+    command: -H unix:///var/run/docker.sock
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer-data:/data
+    labels:
+      # Frontend
+      - traefik.enable=true
+      - #@ template.replace(traefik_tls("portainer"))
+      - traefik.http.routers.portainer.rule=PathPrefix(`/admin/portainer`)
+      - traefik.http.services.portainer.loadbalancer.server.port=9000
+      - traefik.http.routers.portainer.service=portainer
+      - traefik.http.routers.portainer.middlewares=portainer-stripprefix
+      - traefik.http.middlewares.portainer-stripprefix.stripprefix.prefixes=/admin/portainer
+
+
 volumes:
   traefik-public-certificates:
   db-data:
@@ -703,4 +720,6 @@ volumes:
   evaluation-datasets:
     driver: local
   virtuoso-db: 
+    driver: local
+  portainer-data: 
     driver: local

--- a/docker-compose.ytt.yaml
+++ b/docker-compose.ytt.yaml
@@ -697,7 +697,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - portainer-data:/data
     labels:
-      # Frontend
+      #! Frontend
       - traefik.enable=true
       - #@ template.replace(traefik_tls("portainer"))
       - traefik.http.routers.portainer.rule=PathPrefix(`/admin/portainer`)


### PR DESCRIPTION
This PR adds [portainer](https://www.portainer.io/) that provides a simple UI to monitor the deployed services.